### PR TITLE
Allow configuration of arbitrary settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ keepalived_vrrp_instances:
       - '10.127.50.5'
     auth_pass: "{{ vault_vrrp_passwords["VI_3"] }}"
     checks:
-     - chk_nginx
-     - chk_keepalived
+      - chk_nginx
+      - chk_keepalived
+    settings:
+      garp_master_refresh: 20
 
 keepalived_checks:
   "chk_nginx":
@@ -80,6 +82,8 @@ keepalived_notify_smtp_timeout: "30"
 keepalived_notify_list:
   - "noc@example.com"
   - "abuse@example.com"
+keepalived_global_defs:
+  vrrp_garp_master_refresh: 60
 ```
 
 Minimum usage example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,5 @@ keepalived_advert_interval: 1
 keepalived_notify_from: "keepalived@{{ ansible_fqdn }}"
 keepalived_notify_smtp_server: "smtp.example.com"
 keepalived_notify_smtp_timeout: "30"
+keepalived_global_defs: {}
 # vim:ft=ansible:

--- a/templates/etc-keepalived-keepalived.conf.j2
+++ b/templates/etc-keepalived-keepalived.conf.j2
@@ -12,6 +12,9 @@ global_defs {
         {{ email }}
 {% endfor %}
 {% endif %}
+{% for key, value in keepalived_global_defs.iteritems() %}
+    {{ key }} {{ value }}
+{% endfor %}
 }
 
 # Requires keepalived-1.1.13
@@ -53,5 +56,8 @@ vrrp_instance {{ key }} {
 {% endfor %}
     }
 {% endif %}
+{% for k, v in (value.settings | default({})).iteritems() %}
+    {{ k }} {{ v }}
+{% endfor %}
 }
 {% endfor %}


### PR DESCRIPTION
This allows the configuration of arbitrary settings (that are not explicitly handled by this playbook) for `global_defs` and vrrp instances.