### PR TITLE
Fix custom vrrp_scripts always failing

### DIFF
--- a/templates/etc-keepalived-keepalived.conf.j2
+++ b/templates/etc-keepalived-keepalived.conf.j2
@@ -22,7 +22,7 @@ global_defs {
 {% for key, value in keepalived_checks.iteritems() %}
 vrrp_script {{ key }} {
 {% if value.script is defined %}
-    script              "{{ value.script | quote }}"
+    script              "{{ value.script }}"
 {% else %}
     script              "killall -0 {{ value.process }}"
 {% endif %}


### PR DESCRIPTION
Putting the script in quotes AND quoting it was a bit too much,
producing configurations that looked like this:

    vrrp_script  "'pgrep haproxy'"

Removed `quote` to avoid this.